### PR TITLE
lock kopf dependency version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+.venv/
 
 ### Visual Studio Code ###
 .vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 kubernetes
-kopf>=0.20
+kopf==0.28.3


### PR DESCRIPTION
après une tentative de réduire les risques de sécurité levés par snyk, un rebuild de l'image docker a pullé une version 1.29 de kopf, ce qui introduit des breaking changes dans l'opérateur. La version de kopf a été fixée à l'ancienne version, mais une upgrade pourrait être faite éventuellement vers 1.30+