### PR TITLE
Fixed the key error for aws-auth operator in new EKS clusters

### DIFF
--- a/src/kubernetes_operator/iam_mapping.py
+++ b/src/kubernetes_operator/iam_mapping.py
@@ -171,8 +171,10 @@ def get_cm_identity_mappings(configmap: V1ConfigMap) -> list:
     """
     try:
         identities = []
-        identities.extend(yaml.safe_load(configmap.data["mapUsers"]))
-        identities.extend(yaml.safe_load(configmap.data["mapRoles"]))
+        if configmap.data.get("mapUsers"):
+            identities.extend(yaml.safe_load(configmap.data.get("mapUsers")))
+        if configmap.data.get("mapRoles"):
+            identities.extend(yaml.safe_load(configmap.data.get("mapRoles")))
 
         return identities
     except yaml.YAMLError as yaml_error:


### PR DESCRIPTION
Going to need infra team to merge this and deploy it on docker hub.
Pretty sure this is essential to avoid the same authenticator issues while deploying the new test cluster in other envs than dev.

Last time @drobitaille deployed it for us on docker hub.

J:CSEC-14758