### PR TITLE
update apiextension v1beta1 to v1 to deploy crd in kubernetes 1.22

### DIFF
--- a/kubernetes/auth-operator.yaml
+++ b/kubernetes/auth-operator.yaml
@@ -51,7 +51,7 @@ metadata:
   namespace: kube-system
   name: auth-operator
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: auth-operator-role-cluster
@@ -87,7 +87,7 @@ rules:
       - patch
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: auth-operator-rolebinding-cluster

--- a/kubernetes/iamidentitymappings.yaml
+++ b/kubernetes/iamidentitymappings.yaml
@@ -1,39 +1,41 @@
----
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: iamidentitymappings.iamauthenticator.k8s.aws
 spec:
   group: iamauthenticator.k8s.aws
-  version: v1alpha1
-  scope: Cluster
   names:
+    categories:
+    - all
+    kind: IAMIdentityMapping
     plural: iamidentitymappings
     singular: iamidentitymapping
-    kind: IAMIdentityMapping
-    categories:
-      - all
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          oneOf:
-          - required:
-            - userarn
-            - username
-          - required:
-            - rolearn
-            - username
-          properties:
-            groups:
-              items:
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            oneOf:
+            - required:
+              - userarn
+              - username
+            - required:
+              - rolearn
+              - username
+            properties:
+              groups:
+                items:
+                  type: string
+                type: array
+              rolearn:
                 type: string
-              type: array
-            userarn:
-              type: string
-            rolearn:
-              type: string
-            username:
-              type: string
-          type: object
-      type: object
+              userarn:
+                type: string
+              username:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/src/kubernetes_operator/iam_mapping.py
+++ b/src/kubernetes_operator/iam_mapping.py
@@ -129,7 +129,7 @@ def deploy_crd_definition() -> None:
     crd_file_path = get_project_root() / "kubernetes" / "iamidentitymappings.yaml"
     with open(crd_file_path.resolve(), "r") as stream:
         body = yaml.safe_load(stream)
-    extensions_api = client.ApiextensionsV1beta1Api()
+    extensions_api = client.ApiextensionsV1Api()
     crds = extensions_api.list_custom_resource_definition()
     crds_name = {x["metadata"]["name"]: x["metadata"]["resource_version"] for x in crds.to_dict()["items"]}
     crd_name = body["metadata"]["name"]


### PR DESCRIPTION
Hello ,

For this issue https://github.com/coveooss/aws_auth_eks_crd/issues/18 , this new release allow aws_auth_eks_crd to be compatible with kubernetes 1.22